### PR TITLE
Add commands `kcfg block` and `kcfg unblock`

### DIFF
--- a/bash-profile-kcfg-git.sh
+++ b/bash-profile-kcfg-git.sh
@@ -30,6 +30,8 @@ _dir_chomp () {
 }
 export PS1="\[\033[32m\]\$(_dir_chomp \$(pwd) 10)\[\033[33m\]\$(parse_git_branch)\[\033[00m\] \[\033[34m\]\$(basename \"\$KUBECONFIG\")\[\033[00m\] $ "
 
+#### End prompt customization ####
+
 # https://github.com/solsson/kubectx/pull/1
 # Assumption: default config (~/.kube/config) is never a production cluster -- you must explicitly select those per shell
 #chmod a-w ~/.kube/config
@@ -37,8 +39,20 @@ export PS1="\[\033[32m\]\$(_dir_chomp \$(pwd) 10)\[\033[33m\]\$(parse_git_branch
 # TODO how do we get bash completion to work for kubectl aliases?
 alias k="kubectl"
 
+kcfg_block() {
+  KCFG="${1}"
+  echo "Block $KCFG"
+}
+
+kcfg_unblock() {
+  KCFG="${1}"
+  echo "Unblock $KCFG"
+}
+
 kcfg() {
   KCFG="${1}"
+  [ "$KCFG" == "block" ] && kcfg_block "${2}" && return
+  [ "$KCFG" == "unblock" ] && kcfg_unblock "${2}" && return
   # keep config names short and you won't need tab completion :)
   [ ! -f "$KCFG" ] && [ -f "$HOME/.kube/$KCFG" ] && KCFG="$HOME/.kube/$KCFG"
   export KUBECONFIG="$KCFG"
@@ -55,5 +69,3 @@ kcfg() {
   }
   unset namespace
 }
-
-#### End prompt customization ####

--- a/bash-profile-kcfg-git.sh
+++ b/bash-profile-kcfg-git.sh
@@ -41,7 +41,11 @@ alias k="kubectl"
 
 kcfg_block() {
   KCFG="${1}"
-  mv -v "$KCFG" "$KCFG-BLOCKED_KCFG" && echo "kind: kcfgBlocked" > "$KCFG"
+  if [ -f "$KCFG-BLOCKED_KCFG" ]; then
+    echo "Config $KCFG is already blocked"
+  else
+    mv -v "$KCFG" "$KCFG-BLOCKED_KCFG" && echo "kind: kcfgBlocked" > "$KCFG"
+  fi
 }
 
 kcfg_unblock() {

--- a/bash-profile-kcfg-git.sh
+++ b/bash-profile-kcfg-git.sh
@@ -41,12 +41,12 @@ alias k="kubectl"
 
 kcfg_block() {
   KCFG="${1}"
-  echo "Block $KCFG"
+  mv -v "$KCFG" "$KCFG-BLOCKED_KCFG" && echo "kind: kcfgBlocked" > "$KCFG"
 }
 
 kcfg_unblock() {
   KCFG="${1}"
-  echo "Unblock $KCFG"
+  mv -v "$KCFG-BLOCKED_KCFG" "$KCFG"
 }
 
 kcfg_use() {

--- a/bash-profile-kcfg-git.sh
+++ b/bash-profile-kcfg-git.sh
@@ -49,13 +49,8 @@ kcfg_unblock() {
   echo "Unblock $KCFG"
 }
 
-kcfg() {
-  KCFG="${1}"
-  [ "$KCFG" == "block" ] && kcfg_block "${2}" && return
-  [ "$KCFG" == "unblock" ] && kcfg_unblock "${2}" && return
-  # keep config names short and you won't need tab completion :)
-  [ ! -f "$KCFG" ] && [ -f "$HOME/.kube/$KCFG" ] && KCFG="$HOME/.kube/$KCFG"
-  export KUBECONFIG="$KCFG"
+kcfg_use() {
+  export KUBECONFIG="${1}"
   namespaces=$(kubectl --request-timeout 3 get namespace -o jsonpath="{.items[*].metadata.name}")
   [ $? -eq 0 ] && {
     echo -n "Aliases for $(basename $KUBECONFIG):"
@@ -68,4 +63,13 @@ kcfg() {
     echo ""
   }
   unset namespace
+}
+
+kcfg() {
+  KCFGOP="${1}"; KCFG="${2}"
+  [ -z "$KCFG" ] && KCFG="$KCFGOP" && KCFGOP=use
+  [ -z "$KCFG" ] && echo "Usage: kcfg [use|block|unblock] path" && return
+  # keep config names short and you won't need tab completion :)
+  [ ! -f "$KCFG" ] && [ -f "$HOME/.kube/$KCFG" ] && KCFG="$HOME/.kube/$KCFG"
+  kcfg_$KCFGOP "$KCFG"
 }


### PR DESCRIPTION
Blocks the use of a cluster, including from terminals that kcfg'd them earlier.

Meant to prevent mistaken changes to production clusters.

Example:

```
~/R/bash-kubectl-git (block) - $ kcfg minikube
Aliases for minikube:, k-default, k-dgraph, k-kube-node-lease, k-kube-public, k-kube-system, k-monitoring, k-registry
~/R/bash-kubectl-git (block) minikube $ kcfg block minikube
/Users/solsson/.kube/minikube -> /Users/solsson/.kube/minikube-BLOCKED_KCFG
~/R/bash-kubectl-git (block) minikube $ kubectl get pods
error: Error loading config file "/Users/solsson/.kube/minikube": no kind "kcfgBlocked" is registered for version "v1" in scheme "k8s.io/client-go/tools/clientcmd/api/latest/latest.go:50"
~/R/bash-kubectl-git (block) minikube $ kcfg unblock minikube
/Users/solsson/.kube/minikube-BLOCKED_KCFG -> /Users/solsson/.kube/minikube
~/R/bash-kubectl-git (block) minikube $ kubectl get pods
NAME     READY   STATUS    RESTARTS   AGE
toil-0   1/1     Running   2          15d
```