### PR TITLE
Displays current context and namespace using kube-ps1

### DIFF
--- a/bash-profile-kcfg-git.sh
+++ b/bash-profile-kcfg-git.sh
@@ -28,7 +28,7 @@ _dir_chomp () {
     done
     echo "${p[*]}"
 }
-export PS1="\[\033[32m\]\$(_dir_chomp \$(pwd) 10)\[\033[33m\]\$(parse_git_branch)\[\033[00m\] \[\033[34m\]\$(basename \"\$KUBECONFIG\")\[\033[00m\] $ "
+export PS1="\[\033[32m\]\$(_dir_chomp \$(pwd) 10)\[\033[33m\]\$(parse_git_branch)\[\033[00m\] \[\033[34m\]\$(basename \"\$KUBECONFIG\")\[\033[00m\]:$(kube_ps1) $ "
 
 #### End prompt customization ####
 


### PR DESCRIPTION
https://github.com/jonmosco/kube-ps1
with customization:
KUBE_PS1_PREFIX=''
KUBE_PS1_SUFFIX=''
KUBE_PS1_SYMBOL_ENABLE=false

I fail to grasp how to make it work with `kubectl config rename-context`. Prompts seem to lag, probably caused by caching. Other than that it looks good.